### PR TITLE
Fix for more entropy in ids. Sometimes dot was a partof id.

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -62,7 +62,7 @@ CKEDITOR.plugins.add('collapsibleItem', {
                 }
                 var uniqueIdentifier = [
                     (new Date()).getTime(),
-                    ('' + 1e6 * Math.random()).substring(0, 6)
+                    Math.floor(Math.random() * (1e6 - 1e5 - 1)) + 1e5
                 ].join('_');
                 this.setData('accordionId', accordionid);
                 this.setData('itemId', 'Collapsible' + uniqueIdentifier);


### PR DESCRIPTION
Hi! Sorry for mistake in previous commit, however we've tested the new entropy mechanism and found that sometimes dot is added as the last char and collapsible item is not working.